### PR TITLE
[BUGFIX] Event listeners can only work on the TCA coming from $event->getTca() and must not access $GLOBALS['TCA']

### DIFF
--- a/Classes/Service/TcaBuildEventListener.php
+++ b/Classes/Service/TcaBuildEventListener.php
@@ -20,8 +20,9 @@ class TcaBuildEventListener
 
     public function addUuidFieldsToTca(AfterTcaCompilationEvent $event): void
     {
-        $this->service->addUuidFieldsToTca($GLOBALS['TCA']);
+        $loadedTca = $event->getTca();
+        $this->service->addUuidFieldsToTca($loadedTca);
 
-        $event->setTca($GLOBALS['TCA']);
+        $event->setTca($loadedTca);
     }
 }


### PR DESCRIPTION
Related issue: https://github.com/andreaswolf/typo3-ext-uuid/issues/1